### PR TITLE
Mieubrisse/own version constant

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,7 @@
 # TBD
 ### Features
 * Added our own constructors for each of the Protobuf messages, so that when you add a new field it's harder to forget to add it
+* Added a `KurtosisApiVersion` value to Go which contains the version of this library, which is updated automatically during the release process of this repo
 
 ### Fixes
 * Fixed a bug where `stacktrace.Propagate` was incorrectly used instead of `stacktrace.NewError`

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,7 +1,9 @@
 # TBD
 ### Features
 * Added our own constructors for each of the Protobuf messages, so that when you add a new field it's harder to forget to add it
-* Added a `KurtosisApiVersion` value to Go which contains the version of this library, which is updated automatically during the release process of this repo
+* Added constants which contains the version of this library, which is updated automatically during the release process of this repo
+    * Go: `KurtosisApiVersion`
+    * Typescript: `KURTOSIS_API_VERSION`
 
 ### Fixes
 * Fixed a bug where `stacktrace.Propagate` was incorrectly used instead of `stacktrace.NewError`

--- a/golang/lib/kurtosis_api_version_const/kurtosis_api_version_const.go
+++ b/golang/lib/kurtosis_api_version_const/kurtosis_api_version_const.go
@@ -1,0 +1,6 @@
+package kurtosis_api_version_const
+
+const (
+	// DO NOT UPDATE THIS VALUE! It will get updated automaically during the release process
+	KurtosisApiVersion = "0.11.0"
+)

--- a/golang/lib/kurtosis_api_version_const/kurtosis_api_version_const.go
+++ b/golang/lib/kurtosis_api_version_const/kurtosis_api_version_const.go
@@ -1,6 +1,6 @@
 package kurtosis_api_version_const
 
 const (
-	// DO NOT UPDATE THIS VALUE! It will get updated automaically during the release process
+	// DO NOT UPDATE THIS VALUE! It will get updated automatically during the release process
 	KurtosisApiVersion = "0.11.0"
 )

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -19,7 +19,7 @@ UPDATE_OWN_VERSION_CONSTS_SCRIPT_FILENAME="update-own-version-constants.sh"
 # ==================================================================================================
 #                                             Main Logic
 # ==================================================================================================
-if ! bash "${RELEASE_SCRIPT_FILENAME}" "${root_dirpath}" ; then
+if ! bash "${RELEASE_SCRIPT_FILENAME}" "${root_dirpath}" "${script_dirpath}/${UPDATE_OWN_VERSION_CONSTS_SCRIPT_FILENAME}"; then
     echo "Error: Couldn't cut the release" >&2
     exit 1
 fi

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -12,13 +12,14 @@ root_dirpath="$(dirname "${script_dirpath}")"
 #                                             Constants
 # ==================================================================================================
 RELEASE_SCRIPT_FILENAME="release-repo.sh"     # NOTE: Must be on the path; comes from devtools repo
+UPDATE_OWN_VERSION_CONSTS_SCRIPT_FILENAME="update-own-version-constants.sh"
 
 
 
 # ==================================================================================================
 #                                             Main Logic
 # ==================================================================================================
-if ! bash "${RELEASE_SCRIPT_FILENAME}" "${root_dirpath}"; then
+if ! bash "${RELEASE_SCRIPT_FILENAME}" "${root_dirpath}" ; then
     echo "Error: Couldn't cut the release" >&2
     exit 1
 fi

--- a/scripts/update-own-version-constants.sh
+++ b/scripts/update-own-version-constants.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# 2021-07-08 WATERMARK, DO NOT REMOVE - This script was generated from the Kurtosis Bash script template
+
+# In order for testsuites and Lambdas to report the version of Kurtosis API that they depend on, we provide a constant
+#  that contains the version of this library. This script is responsible for updating that constant in all the various
+#  language, and will be run as part of the release flow of this repo.
+
+set -euo pipefail   # Bash "strict mode"
+script_dirpath="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+root_dirpath="$(dirname "${script_dirpath}")"
+
+
+
+# ==================================================================================================
+#                                             Constants
+# ==================================================================================================
+SUPPORTED_LANGS_FILENAME="supported-languages.txt"
+SED_REPLACE_SUFFIX_FOR_DELETION=".DELETEME"
+
+# Go
+GO_CONST_FILE_RELATIVE_FILEPATH="golang/lib/kurtosis_api_version_const/kurtosis_api_version_const.go"
+GO_CONST_NAME="KurtosisApiVersion"
+
+
+
+
+# ==================================================================================================
+#                                       Arg Parsing & Validation
+# ==================================================================================================
+# TODO Modify the arguments below to match the argument to your script
+show_helptext_and_exit() {
+    echo "Usage: $(basename "${0}") new_version"
+    echo ""
+    echo "  new_version     The version of this repo that is about to be released"
+    echo ""
+    exit 1  # Exit with an error so that if this is accidentally called by CI, the script will fail
+}
+
+new_version="${1:-}"
+
+if [ -z "${new_version}" ]; then
+    echo "Error: No new version provided" >&2
+    show_helptext_and_exit
+fi
+
+
+
+# ==================================================================================================
+#                                             Main Logic
+# ==================================================================================================
+function get_update_constant_function_name() {
+    lang="${1}"
+    echo "idempotent_update_${lang}_constant"
+}
+
+# Gets the Go constant pattern, with the value passed in as an arg
+# E.g. if '.*' were passed in to this script, it would form a replace pattern
+# E.g. if '1.2.3' were passed in, it would form an actual string to replace with
+function get_go_constant_pattern() {
+    constant_value="${1}"
+    echo "${GO_CONST_NAME} = \"${value}\""
+}
+
+# vvvvvvvvvvvv There MUST be one idempotent update function per supported language vvvvvvvvvvvvvvvvv
+# Note that, when doing a 'sed' in these functions, you can use the SED_REPLACE_SUFFIX_FOR_DELETION
+#  as the argument to -i, and the file will get deleted at the end of this script
+
+function idempotent_update_golang_constant() {
+    new_version="${1}"
+
+    to_update_filepath="${root_dirpath}/${GO_CONST_FILE_RELATIVE_FILEPATH}"
+    if ! [ -f "${to_update_filepath}" ]; then
+        echo "Error: Needed to update file '${to_update_filepath}' containing Go version constant, but such file doesn't exist" >&2
+        return 1
+    fi
+    if ! search_pattern="$(get_go_constant_pattern ".*")"; then
+        echo "Error: Couldn't form Go constant search pattern" >&2
+        return 1
+    fi
+    num_matching_lines="$(grep "${search_pattern}" "${to_update_filepath}" | wc -l)"
+    if ! [ "${num_matching_lines}" -eq 1 ]; then
+        echo "Error: Expected exactly one line in '${to_update_filepath}' matching pattern '${search_pattern}' but got ${num_matching_lines}" >&2
+        return 1
+    fi
+
+    if ! replace_value="$(get_go_constant_pattern "${new_version}")"; then
+        echo "Error: Couldn't form Go constant replacement value" >&2
+        return 1
+    fi
+    if ! sed "s|${search_pattern}|${replace_value}|" "${to_update_filepath}"; then
+        echo "Error: An error occurred replacing Go constant pattern '${search_pattern}' with value '${replace_value}'" >&2
+        return 1
+    fi
+}
+
+function idempotent_update_typescript_constant() {
+    new_version="${1}"
+}
+# ^^^^^^^^^^^^ There MUST be one idempotent update function per supported language ^^^^^^^^^^^^^^^^^
+
+supported_langs_filepath="${root_dirpath}/${SUPPORTED_LANGS_FILENAME}"
+
+# Before we do any updating, sanity-check that we have update functions for all supported langs
+for lang in "$(cat "${supported_langs_filepath}")"; do
+    expected_function_name="$(get_update_constant_function_name "${lang}")"
+    if [ "$(type -t "${expected_function_name}")" != "function" ]; then
+        echo "Error: We support language '${lang}' but no '${expected_function_name}' function was found in this script; this must be provided!" >&2
+        exit 1
+    fi
+done
+
+echo "Updating the constants containing this library's version for all supported languages..."
+for lang in "$(cat "${supported_langs_filepath}")"; do
+    update_function="$(get_update_constant_function_name "${lang}")"
+    if ! "${update_function}" "${new_version}"; then
+        echo "Error: The function '${update_function}' for updating the ${lang} constant containing this library's version exited with an error" >&2
+        exit 1
+    fi
+done
+if ! find "${root_dirpath}" -name "*${SED_REPLACE_SUFFIX_FOR_DELETION}" -delete; then
+    echo "Error: The constant-replacing succeeded, but an error occurred removing the sed backup files ending with suffix '${SED_REPLACE_SUFFIX_FOR_DELETION}; these will need to be removed manually" >&2
+    exit 1
+fi
+echo "Successfully updated the constants containing this library's version have been updated for all supported languages"

--- a/scripts/update-own-version-constants.sh
+++ b/scripts/update-own-version-constants.sh
@@ -87,7 +87,7 @@ function idempotent_update_golang_constant() {
         echo "Error: Couldn't form Go constant replacement value" >&2
         return 1
     fi
-    if ! sed "s|${search_pattern}|${replace_value}|" "${to_update_filepath}"; then
+    if ! sed -i "${SED_REPLACE_SUFFIX_FOR_DELETION}" "s|${search_pattern}|${replace_value}|" "${to_update_filepath}"; then
         echo "Error: An error occurred replacing Go constant pattern '${search_pattern}' with value '${replace_value}'" >&2
         return 1
     fi

--- a/scripts/update-own-version-constants.sh
+++ b/scripts/update-own-version-constants.sh
@@ -58,7 +58,7 @@ function get_update_constant_function_name() {
 # E.g. if '1.2.3' were passed in, it would form an actual string to replace with
 function get_go_constant_pattern() {
     constant_value="${1}"
-    echo "${GO_CONST_NAME} = \"${value}\""
+    echo "${GO_CONST_NAME} = \"${constant_value}\""
 }
 
 # vvvvvvvvvvvv There MUST be one idempotent update function per supported language vvvvvvvvvvvvvvvvv

--- a/scripts/update-own-version-constants.sh
+++ b/scripts/update-own-version-constants.sh
@@ -101,7 +101,7 @@ function idempotent_update_typescript_constant() {
 supported_langs_filepath="${root_dirpath}/${SUPPORTED_LANGS_FILENAME}"
 
 # Before we do any updating, sanity-check that we have update functions for all supported langs
-for lang in "$(cat "${supported_langs_filepath}")"; do
+for lang in $(cat "${supported_langs_filepath}"); do
     expected_function_name="$(get_update_constant_function_name "${lang}")"
     if [ "$(type -t "${expected_function_name}")" != "function" ]; then
         echo "Error: We support language '${lang}' but no '${expected_function_name}' function was found in this script; this must be provided!" >&2
@@ -110,7 +110,7 @@ for lang in "$(cat "${supported_langs_filepath}")"; do
 done
 
 echo "Updating the constants containing this library's version for all supported languages..."
-for lang in "$(cat "${supported_langs_filepath}")"; do
+for lang in $(cat "${supported_langs_filepath}"); do
     update_function="$(get_update_constant_function_name "${lang}")"
     if ! "${update_function}" "${new_version}"; then
         echo "Error: The function '${update_function}' for updating the ${lang} constant containing this library's version exited with an error" >&2

--- a/scripts/update-own-version-constants.sh
+++ b/scripts/update-own-version-constants.sh
@@ -24,20 +24,20 @@ declare -a CONSTANT_FILE_RELATIVE_FILEPATHS
 declare -a CONSTANT_PATTERN_GETTER_FUNCTION_NAMES
 
 # Go
-CONSTANT_FILE_RELATIVE_FILEPATHS["golang"]="golang/lib/kurtosis_api_version_const/kurtosis_api_version_const.go"
+CONSTANT_FILE_RELATIVE_FILEPATHS[golang]="golang/lib/kurtosis_api_version_const/kurtosis_api_version_const.go"
 function get_go_constant_pattern() {
     value="${1}"
     echo "KurtosisApiVersion = \"${value}\""
 }
-CONSTANT_PATTERN_GETTER_FUNCTION_NAMES["golang"]="get_go_constant_pattern"
+CONSTANT_PATTERN_GETTER_FUNCTION_NAMES[golang]="get_go_constant_pattern"
 
 # Typescript
-CONSTANT_FILE_RELATIVE_FILEPATHS["typescript"]="typescript/lib/kurtosis_api_version_const.ts"
+CONSTANT_FILE_RELATIVE_FILEPATHS[typescript]="typescript/lib/kurtosis_api_version_const.ts"
 function get_typescript_constant_pattern() {
     value="${1}"
     echo "KURTOSIS_API_VERSION: string = \"${value}\""
 }
-CONSTANT_PATTERN_GETTER_FUNCTION_NAMES["typescript"]="get_typescript_constant_pattern"
+CONSTANT_PATTERN_GETTER_FUNCTION_NAMES[typescript]="get_typescript_constant_pattern"
 
 
 # ==================================================================================================

--- a/scripts/update-own-version-constants.sh
+++ b/scripts/update-own-version-constants.sh
@@ -18,26 +18,26 @@ SUPPORTED_LANGS_FILENAME="supported-languages.txt"
 SED_REPLACE_SUFFIX_FOR_DELETION=".DELETEME"
 
 # Per-language filepath that needs updating to update the constant, relative to the repo root
-declare -a CONSTANT_FILE_RELATIVE_FILEPATHS
+declare -A CONSTANT_FILE_RELATIVE_FILEPATHS
 
 # Name of the Bash function which will form the search/replace pattern used for updating the constant
-declare -a CONSTANT_PATTERN_GETTER_FUNCTION_NAMES
+declare -A CONSTANT_PATTERN_GETTER_FUNCTION_NAMES
 
 # Go
-CONSTANT_FILE_RELATIVE_FILEPATHS[golang]="golang/lib/kurtosis_api_version_const/kurtosis_api_version_const.go"
+CONSTANT_FILE_RELATIVE_FILEPATHS["golang"]="golang/lib/kurtosis_api_version_const/kurtosis_api_version_const.go"
 function get_go_constant_pattern() {
     value="${1}"
     echo "KurtosisApiVersion = \"${value}\""
 }
-CONSTANT_PATTERN_GETTER_FUNCTION_NAMES[golang]="get_go_constant_pattern"
+CONSTANT_PATTERN_GETTER_FUNCTION_NAMES["golang"]="get_go_constant_pattern"
 
 # Typescript
-CONSTANT_FILE_RELATIVE_FILEPATHS[typescript]="typescript/lib/kurtosis_api_version_const.ts"
+CONSTANT_FILE_RELATIVE_FILEPATHS["typescript"]="typescript/lib/kurtosis_api_version_const.ts"
 function get_typescript_constant_pattern() {
     value="${1}"
     echo "KURTOSIS_API_VERSION: string = \"${value}\""
 }
-CONSTANT_PATTERN_GETTER_FUNCTION_NAMES[typescript]="get_typescript_constant_pattern"
+CONSTANT_PATTERN_GETTER_FUNCTION_NAMES["typescript"]="get_typescript_constant_pattern"
 
 
 # ==================================================================================================
@@ -99,11 +99,12 @@ function idempotent_update_constant_file_for_lang() {
 # Before we do any updating, sanity-check that we have constant file relative filepaths & search pattern functions for all supported langs
 supported_langs_filepath="${root_dirpath}/${SUPPORTED_LANGS_FILENAME}"
 for lang in $(cat "${supported_langs_filepath}"); do
-    constant_file_rel_filepath=CONSTANT_FILE_RELATIVE_FILEPATHS["${lang}"]
+    constant_file_rel_filepath="${CONSTANT_FILE_RELATIVE_FILEPATHS["${lang}"]}"
     if [ -z "${constant_file_rel_filepath}" ]; then
         echo "Error: No relative filepath to a constant file that needs replacing was found for language '${lang}'; this script needs to be updated with this information" >&2
         exit 1
     fi
+    pattern_getter_function_name="${CONSTANT_PATTERN_GETTER_FUNCTION_NAMES["${lang}"]}"
     if [ -z "${pattern_getter_function_name}" ]; then
         echo "Error: No function name for getting the search/replace pattern was found for language '${lang}'; this script needs to be updated with this information" >&2
         exit 1
@@ -112,8 +113,8 @@ done
 
 echo "Updating the constants containing this library's version for all supported languages..."
 for lang in $(cat "${supported_langs_filepath}"); do
-    constant_file_rel_filepath=CONSTANT_FILE_RELATIVE_FILEPATHS["${lang}"]
-    pattern_getter_function_name=CONSTANT_PATTERN_GETTER_FUNCTION_NAMES["${lang}"]
+    constant_file_rel_filepath="${CONSTANT_FILE_RELATIVE_FILEPATHS["${lang}"]}"
+    pattern_getter_function_name="${CONSTANT_PATTERN_GETTER_FUNCTION_NAMES["${lang}"]}"
 
     if ! idempotent_update_constant_file_for_lang "${lang}" "${pattern_getter_function_name}" "${constant_file_rel_filepath}" "${new_version}"; then
         echo "Error: An error occurred updating the '${lang}' constant in file '${constant_file_rel_filepath}' using constant pattern retrieval function '${pattern_getter_function_name}' to version '${new_version}'" >&2

--- a/supported-languages.txt
+++ b/supported-languages.txt
@@ -1,0 +1,2 @@
+golang
+typescript

--- a/typescript/lib/kurtosis_api_version_const.ts
+++ b/typescript/lib/kurtosis_api_version_const.ts
@@ -1,0 +1,2 @@
+// DO NOT UPDATE THIS VALUE! It will get updated automatically during the release process
+export const KURTOSIS_API_VERSION: string = "0.11.0"


### PR DESCRIPTION
WHY THIS MATTERS:
- It will allow consumers of kurtosis-client to know which version of Kurt Client they're using
- Both Kurt Core & testsuite/Lambdas will know what version they're using... so we can know at runtime if there's an API version mismatch
- *But better yet....* it means that testsuites will now declare what version of the API they need, which means we can get rid of the `.kurtosis` directory in a testsuite and instead just ask the testsuite what version of API container it needs and start that. **This will make upgrading the version of Kurtosis that a testsuite uses as simple as upgrading the Kurt Client dependency**
- This will unlock us being able to have a `kurtosis` CLI, independent of Kurt Core, that can simply take in a testsuite image and figure out the rest (no more `kurtosis.sh` script!)
- Once we have a CLI that can do this.... it's trivial to make a server that can do this 😏 Which would mean unlocking Kurtosis-as-a-Service